### PR TITLE
fix 10.5 compatibility broken in MDEV-19940

### DIFF
--- a/views/p_s/metrics_56.sql
+++ b/views/p_s/metrics_56.sql
@@ -75,6 +75,7 @@
 -- +-----------------------------------------------+-------------------------...+--------------------------------------+---------+
 -- 565 rows in set, 1 warning (0.02 sec)
 
+EXECUTE IMMEDIATE CONCAT("
 CREATE OR REPLACE
   ALGORITHM = TEMPTABLE
   DEFINER = 'root'@'localhost'
@@ -91,7 +92,9 @@ SELECT LOWER(VARIABLE_NAME) AS Variable_name, VARIABLE_VALUE AS Variable_value, 
 ) UNION ALL (
 SELECT NAME AS Variable_name, COUNT AS Variable_value,
        CONCAT('InnoDB Metrics - ', SUBSYSTEM) AS Type,
-       IF(STATUS = 'enabled', 'YES', 'NO') AS Enabled
+       IF(",
+       IF(version() REGEXP '10\.[1-4].*',"STATUS = 'enabled'", "ENABLED"),
+       ", 'YES', 'NO') AS Enabled
   FROM information_schema.INNODB_METRICS
   -- Deduplication - some variables exists both in GLOBAL_STATUS and INNODB_METRICS
   -- Keep the one from GLOBAL_STATUS as it is always enabled and it's more likely to be used for existing tools.
@@ -109,4 +112,4 @@ SELECT 'NOW()' AS Variable_name, NOW(3) AS Variable_value, 'System Time' AS Type
 ) UNION ALL (
 SELECT 'UNIX_TIMESTAMP()' AS Variable_name, ROUND(UNIX_TIMESTAMP(NOW(3)), 3) AS Variable_value, 'System Time' AS Type, 'YES' AS Enabled
 )
- ORDER BY Type, Variable_name;
+ ORDER BY Type, Variable_name");


### PR DESCRIPTION
varchar innodb information_schema columns that where effectively
boolean got replaced by a int in MDEV-19940 in MariaDB-10.5.0.

We use a MariaDB-10.2+ feature EXECUTE IMMEDIATE to form
the VIEW expression correctly based on the version.

Using EXECUTE IMMEDIATE we've effectively broken <=10.1 compatiblity
which is now out of support from MariaDB upstream.

closes #1

I hope this is acceptable @shinguz that provides effective compatibility for supported MariaDB versions.